### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/pytest-minimal.yml
+++ b/.github/workflows/pytest-minimal.yml
@@ -26,7 +26,7 @@ jobs:
           miniforge-version: latest
           condarc-file: ci/condarc
           use-mamba: true
-          python-version: 3.7
+          python-version: 3.8
           environment-file: ci/requirements-minimal.yml
           activate-environment: xarray-extras-minimal
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,38 +1,40 @@
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
+  -   repo: https://github.com/MarcoGorelli/absolufy-imports
+      rev: v0.3.1
+      hooks:
+      - id: absolufy-imports
+        name: absolufy-imports
+  -   repo: https://github.com/pycqa/isort
+      rev: 5.10.1
+      hooks:
       - id: isort
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args:
-          - --py37-plus
-  - repo: https://github.com/psf/black
-    rev: 21.12b0
-    hooks:
+          - --py38-plus
+  -   repo: https://github.com/psf/black
+      rev: 22.1.0
+      hooks:
       - id: black
         language_version: python3
         exclude: versioneer.py
         args:
-          - --target-version=py37
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
+          - --target-version=py38
+  -   repo: https://gitlab.com/pycqa/flake8
+      rev: 4.0.1
+      hooks:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
       - id: mypy
         additional_dependencies:
-          # Type stubs
-          - types-pkg_resources
-          - types-setuptools
           # Libraries exclusively imported under `if TYPE_CHECKING:`
-          - typing_extensions  # To be reviewed after dropping Python 3.7
+          - typing_extensions
           # Typed libraries
           - numpy
           - dask

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,30 +2,30 @@ repos:
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:
-    - id: absolufy-imports
-      name: absolufy-imports
+      - id: absolufy-imports
+        name: absolufy-imports
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
-    - id: isort
-      language_version: python3
+      - id: isort
+        language_version: python3
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.31.1
     hooks:
       - id: pyupgrade
         args:
           - --py38-plus
-  -   repo: https://github.com/psf/black
-      rev: 22.1.0
-      hooks:
+  - repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
       - id: black
         language_version: python3
         exclude: versioneer.py
         args:
           - --target-version=py38
-  -   repo: https://gitlab.com/pycqa/flake8
-      rev: 4.0.1
-      hooks:
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
-  -   repo: https://github.com/MarcoGorelli/absolufy-imports
-      rev: v0.3.1
-      hooks:
-      - id: absolufy-imports
-        name: absolufy-imports
-  -   repo: https://github.com/pycqa/isort
-      rev: 5.10.1
-      hooks:
-      - id: isort
-        language_version: python3
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+    - id: absolufy-imports
+      name: absolufy-imports
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    - id: isort
+      language_version: python3
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.31.1
     hooks:

--- a/ci/requirements-minimal.yml
+++ b/ci/requirements-minimal.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.8
   - dask=2021.4
   - numba=0.52
   - numpy=1.18

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -6,7 +6,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python 3.7 or later
+- Python 3.8 or later
 - `scipy <https://docs.scipy.org/doc/>`__
 - `xarray <http://xarray.pydata.org/>`__
 - `dask <http://dask.pydata.org>`__

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,7 @@ v0.6.0 (Unreleased)
 -------------------
 - Added explicit CI tests for Python 3.10
   (v0.5.0 already supports it, although not formally).
+- Dropped support for Python 3.7
 
 .. _whats-new.0.5.0:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -24,9 +23,8 @@ classifiers =
 packages = xarray_extras
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
-    setuptools  # For pkg_resources
     dask >= 2021.4
     numba >= 0.52
     numpy >= 1.18

--- a/xarray_extras/__init__.py
+++ b/xarray_extras/__init__.py
@@ -1,9 +1,9 @@
-import pkg_resources
+import importlib.metadata
 
 try:
-    __version__ = pkg_resources.get_distribution("xarray_extras").version
-except Exception:  # pragma: nocover
-    # Local copy, not installed with setuptools
+    __version__ = importlib.metadata.version("xarray_extras")
+except importlib.metadata.PackageNotFoundError:  # pragma: nocover
+    # Local copy, not installed with pip
     __version__ = "999"
 
 __all__ = ("__version__",)

--- a/xarray_extras/csv.py
+++ b/xarray_extras/csv.py
@@ -11,7 +11,7 @@ from dask.base import tokenize
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
 
-from .kernels import csv as kernels
+from xarray_extras.kernels import csv as kernels
 
 __all__ = ("to_csv",)
 

--- a/xarray_extras/cumulatives.py
+++ b/xarray_extras/cumulatives.py
@@ -9,7 +9,7 @@ import dask.array as da
 import numpy as np
 import xarray
 
-from .kernels import cumulatives as kernels
+from xarray_extras.kernels import cumulatives as kernels
 
 __all__ = ("cummean", "compound_sum", "compound_prod", "compound_mean")
 

--- a/xarray_extras/interpolate.py
+++ b/xarray_extras/interpolate.py
@@ -9,7 +9,7 @@ import numpy as np
 import xarray
 from xarray.core.pycompat import dask_array_type
 
-from .kernels import interpolate as kernels
+from xarray_extras.kernels import interpolate as kernels
 
 __all__ = ("splrep", "splev")
 

--- a/xarray_extras/kernels/csv.py
+++ b/xarray_extras/kernels/csv.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from .np_to_csv_py import snprintcsvd, snprintcsvi
+from xarray_extras.kernels.np_to_csv_py import snprintcsvd, snprintcsvi
 
 
 def to_csv(

--- a/xarray_extras/kernels/cumulatives.py
+++ b/xarray_extras/kernels/cumulatives.py
@@ -3,7 +3,7 @@
 """
 import numpy as np
 
-from ..numba_extras import guvectorize
+from xarray_extras.numba_extras import guvectorize
 
 
 @guvectorize("{T}[:], intp[:], {T}[:]", "(i),(j)->()")

--- a/xarray_extras/kernels/interpolate.py
+++ b/xarray_extras/kernels/interpolate.py
@@ -14,6 +14,7 @@ from scipy.interpolate._bsplines import _as_float_array, _augknt, _not_a_knot
 if TYPE_CHECKING:  # pragma: nocover
     # TODO Python 3.9 notations
     from typing import Tuple, Union
+
     # TODO import from typing (requires Python 3.10)
     from typing_extensions import TypeAlias
 

--- a/xarray_extras/kernels/interpolate.py
+++ b/xarray_extras/kernels/interpolate.py
@@ -12,12 +12,11 @@ from scipy.interpolate import BSpline, make_interp_spline
 from scipy.interpolate._bsplines import _as_float_array, _augknt, _not_a_knot
 
 if TYPE_CHECKING:  # pragma: nocover
+    # TODO Python 3.9 notations
     from typing import Tuple, Union
+    # TODO import from typing (requires Python 3.10)
+    from typing_extensions import TypeAlias
 
-    from typing_extensions import TypeAlias  # In typing since Python 3.10
-
-    # FIXME mypy should accept Python 3.9 notations
-    #       (tuple instead of Tuple and | instead of Union)
     Boundary: TypeAlias = Iterable[Tuple[int, float]]
     BCType: TypeAlias = Union[Tuple[Boundary, Boundary], str, None]
 

--- a/xarray_extras/kernels/np_to_csv_py.py
+++ b/xarray_extras/kernels/np_to_csv_py.py
@@ -7,7 +7,7 @@ import ctypes
 
 import numpy as np
 
-from . import np_to_csv  # type: ignore
+from xarray_extras.kernels import np_to_csv  # type: ignore
 
 np_to_csv = np.ctypeslib.load_library("np_to_csv", np_to_csv.__file__)
 

--- a/xarray_extras/sort.py
+++ b/xarray_extras/sort.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 
 import xarray
 
-from .duck import sort as duck
+from xarray_extras.duck import sort as duck
 
 __all__ = ("topk", "argtopk", "take_along_dim")
 

--- a/xarray_extras/tests/test_csv.py
+++ b/xarray_extras/tests/test_csv.py
@@ -171,7 +171,7 @@ def test_empty(chunks, nogil, dtype):
     assert_to_csv(x, chunks, nogil, dtype)
 
 
-@pytest.mark.parametrize("x", [0, -(2 ** 63)])
+@pytest.mark.parametrize("x", [0, -(2**63)])
 @pytest.mark.parametrize("index", ["a", "a" * 1000])
 @pytest.mark.parametrize("nogil", [False, True])
 @pytest.mark.parametrize("chunks", [None, 1])


### PR DESCRIPTION
- Drop support for Python 3.7
- Drop dependency from setuptools at runtime
- Add absolufy_imports to CI